### PR TITLE
feat: PM/QC foundation (forms, labels, dashboard, checklists)

### DIFF
--- a/.github/ISSUE_TEMPLATE/daily_log.yml
+++ b/.github/ISSUE_TEMPLATE/daily_log.yml
@@ -1,0 +1,20 @@
+name: Daily Log
+description: Personal daily PM/QC notes
+title: "Daily Log — {{date}}"
+labels: ["Dashboard"]
+body:
+  - type: textarea
+    id: plan
+    attributes:
+      label: Plan for today
+      placeholder: Top 3 and any hard appointments.
+  - type: textarea
+    id: done
+    attributes:
+      label: What I did
+      placeholder: Wins, blockers, context.
+  - type: textarea
+    id: followups
+    attributes:
+      label: Follow-ups
+      placeholder: People to ping, docs to send, etc.

--- a/.github/ISSUE_TEMPLATE/job_qc_audit.yml
+++ b/.github/ISSUE_TEMPLATE/job_qc_audit.yml
@@ -1,0 +1,48 @@
+name: Job QC Audit
+description: Structured audit for a roof job (pre/during/post).
+title: "[QC] <CustomerLastName> — <Street Address>"
+labels: ["QC"]
+body:
+  - type: input
+    id: job_id
+    attributes:
+      label: Job ID / Claim #
+      placeholder: e.g., TCR-24-0912 or 1234567
+    validations:
+      required: true
+  - type: input
+    id: address
+    attributes:
+      label: Address
+      placeholder: 123 Main St, Austin, TX
+    validations:
+      required: true
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Project Phase
+      options:
+        - Pre-Install
+        - In-Progress
+        - Post-Install
+        - Warranty/Service
+    validations:
+      required: true
+  - type: checkboxes
+    id: photo_sets
+    attributes:
+      label: Photo Sets Attached
+      options:
+        - label: Front/Back/Left/Right elevations
+        - label: Roof planes overview
+        - label: Flashings & penetrations
+        - label: Valleys & step flashing
+        - label: Ridge/hip/edge details
+        - label: Underlayment & decking
+        - label: Materials delivery & storage
+        - label: Final cleanup & magnet roll
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / Observations
+      placeholder: Brief bullets; attach photos separately.

--- a/.github/ISSUE_TEMPLATE/punchlist.yml
+++ b/.github/ISSUE_TEMPLATE/punchlist.yml
@@ -1,0 +1,30 @@
+name: Punchlist
+description: Track fixes outstanding on a job.
+title: "[PL] <CustomerLastName> — <Street Address>"
+labels: ["Punchlist"]
+body:
+  - type: input
+    id: job_id
+    attributes:
+      label: Job ID / Claim #
+    validations:
+      required: true
+  - type: textarea
+    id: items
+    attributes:
+      label: Items
+      description: One per line. Use short bullets.
+      placeholder: |
+        - Replace missing ridge cap on N-facing hip
+        - Seal pipe boot @ kitchen vent
+        - Paint exposed fasteners on drip edge
+  - type: dropdown
+    id: status
+    attributes:
+      label: Status
+      options:
+        - New
+        - Scheduled
+        - In Progress
+        - Blocked
+        - Done

--- a/.github/ISSUE_TEMPLATE/vendor_inspection.yml
+++ b/.github/ISSUE_TEMPLATE/vendor_inspection.yml
@@ -1,0 +1,30 @@
+name: Vendor/Material Inspection
+description: Record vendor deliveries and material checks
+title: "[Vendor] <Supplier> — <PO or Ticket>"
+labels: ["Vendor","Materials"]
+body:
+  - type: input
+    id: supplier
+    attributes:
+      label: Supplier
+      placeholder: e.g., ABC Supply
+    validations:
+      required: true
+  - type: textarea
+    id: materials
+    attributes:
+      label: Materials received
+      placeholder: |
+        - Shingle: 3-tab IR, driftwood, 75 bundles
+        - Underlayment: synthetic, 10 rolls
+        - Drip edge: black, 250 ft
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: Counts match PO
+        - label: Pallets wrapped/covered
+        - label: Stored off ground
+        - label: No visible damage
+        - label: Color/lot matched

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,12 @@
+[
+  {"name":"QC","color":"0e8a16","description":"Quality Control / Audit"},
+  {"name":"Punchlist","color":"c5def5","description":"Outstanding fixes"},
+  {"name":"Safety","color":"d93f0b","description":"Safety concerns / reports"},
+  {"name":"Urgent","color":"b60205","description":"High priority"},
+  {"name":"Scheduling","color":"5319e7","description":"Calendar / timing"},
+  {"name":"Materials","color":"1d76db","description":"Vendors, materials, delivery"},
+  {"name":"Warranty","color":"f9d0c4","description":"Warranty matters"},
+  {"name":"Customer","color":"fbca04","description":"Customer communication"},
+  {"name":"Vendor","color":"e99695","description":"Vendor coordination"},
+  {"name":"Dashboard","color":"ededed","description":"Bot-created status issues"}
+]

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -1,0 +1,47 @@
+name: Daily QC Digest
+on:
+  schedule:
+    - cron: "30 12 * * *"  # 07:30 America/Chicago
+  workflow_dispatch: {}
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build digest body
+        id: body
+        run: |
+          TODAY="$(date -u +%F)"
+          echo "## QC Dashboard — $TODAY" > body.md
+          echo "" >> body.md
+          echo "### Open Punchlists" >> body.md
+          echo "" >> body.md
+          gh issue list --label 'Punchlist' --state open --limit 50 --json number,title,state,labels --template '{{range .}}{{.number}} · {{.title}}{{"\\n"}}{{end}}' >> body.md || true
+          echo "" >> body.md
+          echo "### Audits Due (label: QC)" >> body.md
+          echo "" >> body.md
+          gh issue list --label 'QC' --state open --limit 50 --json number,title,state,labels --template '{{range .}}{{.number}} · {{.title}}{{"\\n"}}{{end}}' >> body.md || true
+          echo "" >> body.md
+          echo "### Urgent" >> body.md
+          echo "" >> body.md
+          gh issue list --label 'Urgent' --state open --limit 50 --json number,title,state,labels --template '{{range .}}{{.number}} · {{.title}}{{"\\n"}}{{end}}' >> body.md || true
+          echo "BODY<<EOF" >> $GITHUB_OUTPUT
+          sed -n '1,200p' body.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Open or update today's digest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="QC Dashboard — $(date -u +%F)"
+          NUM=$(gh issue list --search "in:title $(date -u +%F) QC Dashboard" --json number --jq ".[0].number" || true)
+          if [ -z "$NUM" ] || [ "$NUM" = "null" ]; then
+            gh issue create --title "$TITLE" --body "${{ steps.body.outputs.BODY }}" --label "QC,Dashboard"
+          else
+            gh issue comment "$NUM" --body "🔄 Auto-update at $(date -u +%H:%M) UTC"
+            gh issue edit "$NUM" --body "${{ steps.body.outputs.BODY }}"
+          fi

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,19 @@
+name: Sync Labels
+on:
+  push:
+    paths:
+      - .github/labels.json
+  workflow_dispatch: {}
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.json
+          skip-delete: false

--- a/.github/workflows/post-checklist.yml
+++ b/.github/workflows/post-checklist.yml
@@ -1,0 +1,28 @@
+name: Post Checklist on Issue
+on:
+  issues:
+    types: [opened, edited]
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine checklist
+        id: pick
+        run: |
+          LABELS="$(jq -r '[ .issue.labels[].name ] | join(",")' < $GITHUB_EVENT_PATH)"
+          FILE=""
+          if echo "$LABELS" | grep -qi "Punchlist"; then FILE="docs/checklists/punchlist.md"; fi
+          if echo "$LABELS" | grep -qi "QC"; then FILE="docs/checklists/job-qc-audit.md"; fi
+          if echo "$LABELS" | grep -qi "Safety"; then FILE="docs/checklists/safety-spotcheck.md"; fi
+          echo "file=$FILE" >> $GITHUB_OUTPUT
+      - name: Update issue body
+        if: steps.pick.outputs.file != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BODY="$(cat ${{ steps.pick.outputs.file }})"
+          gh issue edit ${{ github.event.issue.number }} --body "$BODY"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # PM-QC-TCR
 Project Management and Quality Control 
 -a hub and resoirce for scheduling, time, mterial and labor teacking. 
+
+## How to Use
+- Open **Issues → New issue** and choose the right form (QC Audit, Punchlist, Daily Log, Vendor/Material Inspection).
+- Review bot posts: the **Daily QC Digest** opens/updates an issue each morning (~07:30 CT).
+- Labels stay in sync via `.github/labels.json`; run the *Sync Labels* workflow after edits.
+
+See `ops/kodex/CODEX.md` for the daily Kodex task menu.

--- a/docs/checklists/job-qc-audit.md
+++ b/docs/checklists/job-qc-audit.md
@@ -1,0 +1,13 @@
+# Job QC Audit — Checklist
+
+- [ ] **Permits & HOA** posted/approved
+- [ ] **Decking** sound; replace rot/soft spots; nails flush
+- [ ] **Underlayment** overlapped, nailed per spec; valleys reinforced
+- [ ] **Flashing**: step, counter, apron, chimney cricket as needed
+- [ ] **Penetrations**: boots sized/sealed; satellite re-mounted/marked
+- [ ] **Edges**: drip edge continuous; starter course aligned
+- [ ] **Shingles/Panels** aligned; fastener pattern per manufacturer
+- [ ] **Ridge/Hip** caps correct; ventilation clear
+- [ ] **Site**: tarps, magnet sweep, nails/debris removed
+- [ ] **Photos**: elevations, planes, details, serials, materials
+- [ ] **Customer** walk-through + signoff

--- a/docs/checklists/punchlist.md
+++ b/docs/checklists/punchlist.md
@@ -1,0 +1,6 @@
+# Punchlist — Checklist
+
+Add items below as task list:
+- [ ] Item 1
+- [ ] Item 2
+- [ ] Item 3

--- a/docs/checklists/safety-spotcheck.md
+++ b/docs/checklists/safety-spotcheck.md
@@ -1,0 +1,8 @@
+# Safety Spot-Check
+
+- [ ] Harnesses tied-off (100%)
+- [ ] Ladders 3' above roof, secured
+- [ ] Toe-boards/guarding as required
+- [ ] Weather within safe limits
+- [ ] House perimeter protected; signage
+- [ ] First-aid and extinguisher on site

--- a/ops/kodex/CODEX.md
+++ b/ops/kodex/CODEX.md
@@ -1,0 +1,20 @@
+# Kodex Ops Prompt — PM/QC @ Texas Choice Roofing
+
+## Prime Directives
+- Keep GitHub the **single source of truth** for tasks, QC, punchlists.
+- Use issue templates and labels; avoid free-form issues when possible.
+- Prefer edits/comments over new issues when updating the same job.
+
+## Task Menu
+1) **Open Job QC Audit** — use the `Job QC Audit` form; label `QC`.
+2) **Open Punchlist** — use `Punchlist` form; link to the related QC issue.
+3) **Daily Log** — use `Daily Log` form for personal notes.
+4) **Morning Digest** — ensure a `QC Dashboard — <YYYY-MM-DD>` exists.
+
+## Style
+- Short bullets; start with verbs.
+- Link photos; group by area.
+- Keep address/ID consistent across artifacts.
+
+## Safety
+- Escalate anything labeled `Safety` + `Urgent` by @-mentioning the PM on duty.


### PR DESCRIPTION
## Summary
- add standard PM/QC label catalog with automation to sync
- introduce QC audit, punchlist, daily log, and vendor/material issue forms plus auto-checklists
- schedule a daily QC digest issue and document the Kodex task menu with README usage notes

## Testing
- open "Punchlist" issue via Issues → New issue to confirm checklist replacement
- run "Sync Labels" and "Daily QC Digest" workflows via Actions → Run workflow

------
https://chatgpt.com/codex/tasks/task_e_68d7d08f0fd8832c80793e2d1a1860ba